### PR TITLE
ci: testing failing check-coverage

### DIFF
--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -12,11 +12,10 @@ contract CounterTest is Test {
         counter.setNumber(0);
     }
 
-    // Just for testing
-    // function test_Increment() public {
-    //     counter.increment();
-    //     assertEq(counter.number(), 1);
-    // }
+    function test_Increment() public {
+        counter.increment();
+        assertEq(counter.number(), 1);
+    }
 
     function testFuzz_SetNumber(uint256 x) public {
         counter.setNumber(x);

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -12,10 +12,11 @@ contract CounterTest is Test {
         counter.setNumber(0);
     }
 
-    function test_Increment() public {
-        counter.increment();
-        assertEq(counter.number(), 1);
-    }
+    // Just for testing
+    // function test_Increment() public {
+    //     counter.increment();
+    //     assertEq(counter.number(), 1);
+    // }
 
     function testFuzz_SetNumber(uint256 x) public {
         counter.setNumber(x);

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -8,18 +8,19 @@ contract CounterTest is Test {
     Counter public counter;
 
     function setUp() public {
-        counter = new Counter();
-        counter.setNumber(0);
+        // counter = new Counter();
+        // counter.setNumber(0);
     }
 
     // Just for testing
-    // function test_Increment() public {
-    //     counter.increment();
-    //     assertEq(counter.number(), 1);
-    // }
+    function test_Increment() public {
+        // counter.increment();
+        // assertEq(counter.number(), 1);
+    }
 
+    // Just for testing
     function testFuzz_SetNumber(uint256 x) public {
-        counter.setNumber(x);
-        assertEq(counter.number(), x);
+        // counter.setNumber(x);
+        // assertEq(counter.number(), x);
     }
 }


### PR DESCRIPTION
- [x] coverage check fails -> action unsuccessful -> result commented ([540051b](https://github.com/zkemail/solidity-template/pull/4/commits/540051b36b84d85b0bdec2769801d4310a4392d7))
- [x] fail comment updated with success comment ([ea0eb1e](https://github.com/zkemail/solidity-template/pull/4/commits/ea0eb1eebfc1c83346e3eb8b8236fd88f1c2a984))
- [x] fail comment updated with fail comment (with different %) ([288e675](https://github.com/zkemail/solidity-template/pull/4/commits/288e6756ffc7e407eeda7ece806f1f5fb710acca))